### PR TITLE
Fix docs formatting

### DIFF
--- a/docs/types/objects.md
+++ b/docs/types/objects.md
@@ -110,7 +110,7 @@ public class Donut
     public string Name { get; set; }
     public DonutType Type { get; set; }
 
-    /highlight-next-line
+    // highlight-next-line
     [GraphSkip]
     public decimal Price { get; set; }
 }


### PR DESCRIPTION
A missing slash means the highlighting is not rendered correctly:

![Screenshot 2023-06-08 at 11 25 23](https://github.com/dylan8902/graphql-aspnet.github.io/assets/150938/c6751f24-34ea-4c15-b31c-dae64d7f5b9c)

This fixes that